### PR TITLE
cmake: don't install headers if pokehack is used as a submodule for another project, standard builds are unaffected

### DIFF
--- a/include/pokehack/CMakeLists.txt
+++ b/include/pokehack/CMakeLists.txt
@@ -1,5 +1,7 @@
 FILE(GLOB pokehack_headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
 
-FOREACH(header ${pokehack_headers})
-    INSTALL(FILES ${header} DESTINATION ${INCLUDE_DIR}/pokehack COMPONENT Headers)
-ENDFOREACH(header)
+IF(NOT USED_AS_SUBMODULE)
+    FOREACH(header ${pokehack_headers})
+        INSTALL(FILES ${header} DESTINATION ${INCLUDE_DIR}/pokehack COMPONENT Headers)
+    ENDFOREACH(header)
+ENDIF(NOT USED_AS_SUBMODULE)


### PR DESCRIPTION
As the commit says, you won't notice anything. PKMNsim uses my mirror of Pokehack as a Git submodule and links against the library. When using my trainer class, all the user specifies is a filename and the game to expect it to be. If it's Gen 3, it uses Pokehack; if it's Gen 4, it uses PokeLib. The user doesn't see the underlying implementation, just my interface. Thus, beyond build time, PKMNsim doesn't need the Pokehack headers.

When installing Pokehack standalone, the headers are still installed.
